### PR TITLE
Correctly encode non-ASCII string entities.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+1.1.1 (2016-10-12)
+------------------
+
+* Non-ASCII characters are now correctly encoded as UTF-8 in the request body.
+  Reported by Julien Guery. GitHub #17.
+
 1.1.0 (2016-10-10)
 ------------------
 

--- a/src/main/java/com/maxmind/minfraud/WebServiceClient.java
+++ b/src/main/java/com/maxmind/minfraud/WebServiceClient.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 import java.net.*;
 import java.util.*;
 
+import static org.apache.http.entity.ContentType.APPLICATION_JSON;
+
 /**
  * Client for MaxMind minFraud Score, Insights, and Factors
  */
@@ -309,8 +311,7 @@ public final class WebServiceClient implements Closeable {
 
         String requestBody = transaction.toJson();
 
-        StringEntity input = new StringEntity(requestBody);
-        input.setContentType("application/json");
+        StringEntity input = new StringEntity(requestBody, APPLICATION_JSON);
 
         request.setEntity(input);
         return request;

--- a/src/test/java/com/maxmind/minfraud/WebServiceClientTest.java
+++ b/src/test/java/com/maxmind/minfraud/WebServiceClientTest.java
@@ -2,6 +2,8 @@ package com.maxmind.minfraud;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.maxmind.minfraud.exception.*;
+import com.maxmind.minfraud.request.Device;
+import com.maxmind.minfraud.request.Shipping;
 import com.maxmind.minfraud.request.Transaction;
 import com.maxmind.minfraud.response.FactorsResponse;
 import com.maxmind.minfraud.response.InsightsResponse;
@@ -13,6 +15,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.net.InetAddress;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.jcabi.matchers.RegexMatchers.matchesPattern;
@@ -67,6 +71,23 @@ public class WebServiceClientTest {
             // We cannot change this as it would be a breaking change to the GeoIP2 API.
             JSONAssert.assertEquals(responseContent, response.toJson(), false);
             verifyRequestFor("factors");
+        }
+    }
+
+    @Test
+    public void testRequestEncoding() throws Exception {
+        try (WebServiceClient client = createSuccessClient("insights", "{}")) {
+            Transaction request = new Transaction.Builder(
+                    new Device.Builder(InetAddress.getByName("1.1.1.1")).build()
+            ).shipping(
+                    new Shipping.Builder()
+                            .firstName("Allan dias á s maia")
+                            .build()
+            ).build();
+            client.insights(request);
+
+            verify(postRequestedFor(urlMatching("/minfraud/v2.0/insights"))
+                    .withRequestBody(equalToJson("{\"device\":{\"ip_address\":\"1.1.1.1\"},\"shipping\":{\"first_name\":\"Allan dias á s maia\"}}")));
         }
     }
 

--- a/src/test/java/com/maxmind/minfraud/request/RequestTestHelper.java
+++ b/src/test/java/com/maxmind/minfraud/request/RequestTestHelper.java
@@ -128,6 +128,6 @@ public class RequestTestHelper {
 
         verify(postRequestedFor(urlMatching("/minfraud/v2.0/" + service))
                 .withRequestBody(equalToJson(requestBody))
-                .withHeader("Content-Type", matching("application/json")));
+                .withHeader("Content-Type", matching("application/json; charset=UTF-8")));
     }
 }


### PR DESCRIPTION
Fixes GitHub #17