### PR TITLE
added support of Proxy.NO_PROXY in web service client builder

### DIFF
--- a/src/main/java/com/maxmind/minfraud/WebServiceClient.java
+++ b/src/main/java/com/maxmind/minfraud/WebServiceClient.java
@@ -68,7 +68,7 @@ public final class WebServiceClient implements Closeable {
                 .setConnectTimeout(builder.connectTimeout)
                 .setSocketTimeout(builder.readTimeout);
 
-        if (builder.proxy != null) {
+        if (builder.proxy != null && builder.proxy != Proxy.NO_PROXY) {
             InetSocketAddress address = (InetSocketAddress) builder.proxy.address();
             HttpHost proxyHost = new HttpHost(address.getHostName(), address.getPort());
             configBuilder.setProxy(proxyHost);


### PR DESCRIPTION
`Proxy.NO_PROXY` is a standard way to indicate a direct connection. However, right now it is impossible to write something similar to:
```
Proxy proxy = readProxyConfig(...);
builder.proxy(proxy).build();
```

This PR fixes the behavior of the `WebServiceClient`.