### PR TITLE
Add support for 8 digit IINs and 2 digit lastDigits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,22 @@ CHANGELOG
   * `PAYVISION`
   * `TRUSTLY`
   * `WINDCAVE`
+* `com.maxmind.minfraud.request.CreditCard.last4Digits` has been deprecated in
+   favor of `lastDigits` and will be removed in a future release. `lastDigits`
+   / `last4Digits` also now supports two digit values in addition to the
+   previous four digit values.
+* Eight digit `com.maxmind.minfraud.request.CreditCard.issuerIdNumber` inputs are
+  now supported in addition to the previously accepted six digit `issuerIdNumber`.
+  In most cases, you should send the last four digits for
+  `com.maxmind.minfraud.request.CreditCard.last4Digits`. If you send a
+  `issuerIdNumber` that contains an eight digit IIN, and if the credit card brand
+  is not one of the following, you should send the last two digits for
+  `lastDigits`:
+  * `Discover`
+  * `JCB`
+  * `Mastercard`
+  * `UnionPay`
+  * `Visa`
 
 1.18.0 (2021-08-31)
 -------------------

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Transaction request = new Transaction.Builder(
             .bankPhoneNumber("313-231-3213")
             .cvvResult('Y')
             .issuerIdNumber("213312")
-            .last4Digits("3211")
+            .lastDigits("3211")
             .was3dSecureSuccessful(true)
             .build()
     ).email(

--- a/src/main/java/com/maxmind/minfraud/request/CreditCard.java
+++ b/src/main/java/com/maxmind/minfraud/request/CreditCard.java
@@ -1,5 +1,6 @@
 package com.maxmind.minfraud.request;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.maxmind.minfraud.AbstractModel;
 
@@ -10,7 +11,7 @@ import java.util.regex.Pattern;
  */
 public final class CreditCard extends AbstractModel {
     private final String issuerIdNumber;
-    private final String last4Digits;
+    private final String lastDigits;
     private final String bankName;
     private final String bankPhoneCountryCode;
     private final String bankPhoneNumber;
@@ -21,7 +22,7 @@ public final class CreditCard extends AbstractModel {
 
     private CreditCard(CreditCard.Builder builder) {
         issuerIdNumber = builder.issuerIdNumber;
-        last4Digits = builder.last4Digits;
+        lastDigits = builder.lastDigits;
         bankName = builder.bankName;
         bankPhoneCountryCode = builder.bankPhoneCountryCode;
         bankPhoneNumber = builder.bankPhoneNumber;
@@ -36,12 +37,12 @@ public final class CreditCard extends AbstractModel {
      * from values set by the builder's methods.
      */
     public static final class Builder {
-        private static final Pattern IIN_PATTERN = Pattern.compile("^[0-9]{6}$");
-        private static final Pattern LAST_4_PATTERN = Pattern.compile("^[0-9]{4}$");
+        private static final Pattern IIN_PATTERN = Pattern.compile("^(?:[0-9]{6}|[0-9]{8})$");
+        private static final Pattern LAST_DIGITS_PATTERN = Pattern.compile("^(?:[0-9]{2}|[0-9]{4})$");
         private static final Pattern TOKEN_PATTERN = Pattern.compile("^(?![0-9]{1,19}$)[\\x21-\\x7E]{1,255}$");
 
         String issuerIdNumber;
-        String last4Digits;
+        String lastDigits;
         String bankName;
         String bankPhoneCountryCode;
         String bankPhoneNumber;
@@ -52,7 +53,7 @@ public final class CreditCard extends AbstractModel {
 
         /**
          * @param number The issuer ID number for the credit card. This is the
-         *               first 6 digits of the credit card number. It
+         *               first 6 or 8 digits of the credit card number. It
          *               identifies the issuing bank.
          * @return The builder object.
          * @throws IllegalArgumentException when number is not a six digit
@@ -67,16 +68,30 @@ public final class CreditCard extends AbstractModel {
         }
 
         /**
-         * @param digits The last four digits of the credit card number.
+         * @deprecated
+         * Use lastDigits instead.
+         *
+         * @param digits The last two or four digits of the credit card number.
          * @return The builder object.
-         * @throws IllegalArgumentException when number is not a four digit
+         * @throws IllegalArgumentException when number is not a two or four digit
          *                                  string.
          */
+        @Deprecated
         public CreditCard.Builder last4Digits(String digits) {
-            if (!LAST_4_PATTERN.matcher(digits).matches()) {
-                throw new IllegalArgumentException("The last 4 credit card digits " + digits + " are of the wrong format.");
+            return this.lastDigits(digits);
+        }
+
+        /**
+         * @param digits The last two or four digits of the credit card number.
+         * @return The builder object.
+         * @throws IllegalArgumentException when number is not a two or four digit
+         *                                  string.
+         */
+        public CreditCard.Builder lastDigits(String digits) {
+            if (!LAST_DIGITS_PATTERN.matcher(digits).matches()) {
+                throw new IllegalArgumentException("The last credit card digits " + digits + " are of the wrong format.");
             }
-            last4Digits = digits;
+            lastDigits = digits;
             return this;
         }
 
@@ -188,11 +203,22 @@ public final class CreditCard extends AbstractModel {
     }
 
     /**
-     * @return The last 4 digits of the credit card number.
+     * @deprecated
+     *
+     * @return The last two or four digits of the credit card number.
      */
-    @JsonProperty("last_4_digits")
+    @Deprecated
+    @JsonIgnore
     public String getLast4Digits() {
-        return last4Digits;
+        return this.getLastDigits();
+    }
+
+    /**
+     * @return The last two or four digits of the credit card number.
+     */
+    @JsonProperty("last_digits")
+    public String getLastDigits() {
+        return lastDigits;
     }
 
     /**

--- a/src/test/java/com/maxmind/minfraud/request/CreditCardTest.java
+++ b/src/test/java/com/maxmind/minfraud/request/CreditCardTest.java
@@ -16,6 +16,9 @@ public class CreditCardTest {
     public void testIssuerIdNumber() {
         CreditCard cc = new Builder().issuerIdNumber("123456").build();
         assertEquals("123456", cc.getIssuerIdNumber());
+
+        cc = new Builder().issuerIdNumber("12345678").build();
+        assertEquals("12345678", cc.getIssuerIdNumber());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -37,21 +40,33 @@ public class CreditCardTest {
     public void testLast4Digits() {
         CreditCard cc = new Builder().last4Digits("1234").build();
         assertEquals("1234", cc.getLast4Digits());
+        assertEquals("1234", cc.getLastDigits());
+    }
+
+    @Test
+    public void testLastDigits() {
+        CreditCard cc = new Builder().lastDigits("1234").build();
+        assertEquals("1234", cc.getLast4Digits());
+        assertEquals("1234", cc.getLastDigits());
+
+        cc = new Builder().lastDigits("12").build();
+        assertEquals("12", cc.getLast4Digits());
+        assertEquals("12", cc.getLastDigits());
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testLast4DigitsThatIsTooLong() {
-        new Builder().last4Digits("12345").build();
+    public void testLastDigitsThatIsTooLong() {
+        new Builder().lastDigits("12345").build();
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testLast4DigitsThatIsTooShort() {
-        new Builder().last4Digits("123").build();
+    public void testLastDigitsThatIsTooShort() {
+        new Builder().lastDigits("123").build();
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testLast4DigitsThatHasLetters() {
-        new Builder().last4Digits("123a").build();
+    public void testLastDigitsThatHasLetters() {
+        new Builder().lastDigits("123a").build();
     }
 
     @Test

--- a/src/test/java/com/maxmind/minfraud/request/RequestTestHelper.java
+++ b/src/test/java/com/maxmind/minfraud/request/RequestTestHelper.java
@@ -109,7 +109,7 @@ public class RequestTestHelper {
                                 .bankPhoneNumber("123-456-1234")
                                 .avsResult('Y')
                                 .cvvResult('N')
-                                .last4Digits("7643")
+                                .lastDigits("7643")
                                 .token("123456abc1234")
                                 .was3dSecureSuccessful(true)
                                 .build()

--- a/src/test/resources/test-data/full-request-email-md5.json
+++ b/src/test/resources/test-data/full-request-email-md5.json
@@ -47,7 +47,7 @@
   },
   "credit_card": {
     "issuer_id_number": "411111",
-    "last_4_digits": "7643",
+    "last_digits": "7643",
     "bank_name": "Bank of No Hope",
     "bank_phone_country_code": "1",
     "bank_phone_number": "123-456-1234",

--- a/src/test/resources/test-data/full-request.json
+++ b/src/test/resources/test-data/full-request.json
@@ -47,7 +47,7 @@
   },
   "credit_card": {
     "issuer_id_number": "411111",
-    "last_4_digits": "7643",
+    "last_digits": "7643",
     "bank_name": "Bank of No Hope",
     "bank_phone_country_code": "1",
     "bank_phone_number": "123-456-1234",


### PR DESCRIPTION
Previously issuerIdNumber was expected to be 6 digits and
last4Digits to be 4 digits. This changes the validation to
additionally allow for 8 digit issuerIdNumbers and 2 digit
last4Digits.

Additionally last4Digits has been deprecated in favor of the
more appropriately named lastDigits.