### PR TITLE
Update geoip2 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.maxmind.geoip2</groupId>
             <artifactId>geoip2</artifactId>
-            <version>4.0.1</version>
+            <version>4.1.0</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>


### PR DESCRIPTION
geoip2 version 4.1.0 introduced new ConnectionType enum value "Satellite". https://github.com/maxmind/GeoIP2-java/blob/204a979c2759632a465519c4e459261f01a3f9b8/src/main/java/com/maxmind/geoip2/model/ConnectionTypeResponse.java#L60
We can't deserialize maxmind response because mindfruad is using the old version of geoip2 which doesn't have the "Satellite" enum value. 