### PR TITLE
Remove ossrh-snapshots repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,10 @@
         </plugins>
     </build>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <reporting>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -226,11 +226,6 @@
             </plugin>
         </plugins>
     </build>
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
 
     <reporting>
         <plugins>

--- a/src/main/java/com/maxmind/minfraud/request/Device.java
+++ b/src/main/java/com/maxmind/minfraud/request/Device.java
@@ -50,7 +50,7 @@ public final class Device extends AbstractModel {
         }
 
         /**
-         * @param ua The HTTP “User-Agent” header of the browser used in
+         * @param ua The HTTP "User-Agent" header of the browser used in
          *           the transaction.
          * @return The builder object.
          */
@@ -60,7 +60,7 @@ public final class Device extends AbstractModel {
         }
 
         /**
-         * @param acceptLanguage The HTTP “Accept-Language” header of the
+         * @param acceptLanguage The HTTP "Accept-Language" header of the
          *                       device used in the transaction.
          * @return The builder object.
          */

--- a/src/main/java/com/maxmind/minfraud/response/Warning.java
+++ b/src/main/java/com/maxmind/minfraud/response/Warning.java
@@ -33,7 +33,7 @@ public final class Warning extends AbstractModel {
      * <li>BILLING_POSTAL_NOT_FOUND – the billing postal could not be found
      * in our database.</li>
      * <li>INPUT_INVALID – the value associated with the key does not meet
-     * the required constraints, e.g., “United States” in a field that
+     * the required constraints, e.g., "United States" in a field that
      * requires a two-letter country code.</li>
      * <li>INPUT_UNKNOWN – an unknown key was encountered in the request
      * body.</li>


### PR DESCRIPTION
Dependabot will stop looking for maven dependencies once it finds a repository that returns any number of results, even if none of those results match the requested version. This removes the ossrh repository because it brings in snapshot repositories that prevent dependabot from falling back to the central repository. See: https://github.com/dependabot/dependabot-core/pull/5872