### PR TITLE
Release 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+3.3.0 (2023-12-05)
+------------------
+
+* Updated `geoip2` dependency to version that includes the `isAnycast` method
+  on `com.maxmind.geoip2.record.Traits`. This returns `true` if the IP
+  address belongs to an [anycast network](https://en.wikipedia.org/wiki/Anycast).
+  This is available in minFraud Insights and Factors.
+
 3.2.0 (2023-10-27)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To do this, add the dependency to your pom.xml:
     <dependency>
         <groupId>com.maxmind.minfraud</groupId>
         <artifactId>minfraud</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
     </dependency>
 ```
 
@@ -29,7 +29,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile 'com.maxmind.minfraud:minfraud:3.2.0'
+    compile 'com.maxmind.minfraud:minfraud:3.3.0'
 }
 ```
 

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -123,5 +123,3 @@ git push --tags
 gh release create --target "$(git branch --show-current)" -t "$version" -n "$notes" "$tag" \
     "target/minfraud-$version-with-dependencies.zip" \
     "target/minfraud-$version-with-dependencies.zip.asc"
-
-echo "Remember to do the release on https://oss.sonatype.org/!"

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -93,7 +93,7 @@ mvn release:clean
 mvn release:prepare -DreleaseVersion="$version" -Dtag="$tag"
 mvn release:perform
 rm -fr ".gh-pages/doc/$tag"
-cp -r target/apidocs ".gh-pages/doc/$tag"
+cp -r target/checkout/target/apidocs ".gh-pages/doc/$tag"
 
 pushd .gh-pages
 
@@ -121,5 +121,5 @@ git push
 git push --tags
 
 gh release create --target "$(git branch --show-current)" -t "$version" -n "$notes" "$tag" \
-    "target/minfraud-$version-with-dependencies.zip" \
-    "target/minfraud-$version-with-dependencies.zip.asc"
+    "target/checkout/target/minfraud-$version-with-dependencies.zip" \
+    "target/checkout/target/minfraud-$version-with-dependencies.zip.asc"

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.maxmind.geoip2</groupId>
             <artifactId>geoip2</artifactId>
-            <version>4.1.0</version>
+            <version>4.2.0</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.maxmind.minfraud</groupId>
     <artifactId>minfraud</artifactId>
-    <version>3.3.0</version>
+    <version>3.3.1-SNAPSHOT</version>
     <name>MaxMind minFraud Score, Insights, Factors and Report Transaction API</name>
     <description>MaxMind minFraud Score, Insights, Factors and Report Transaction API</description>
     <url>http://dev.maxmind.com/minfraud</url>
@@ -23,7 +23,7 @@
         <url>https://github.com/maxmind/minfraud-api-java</url>
         <connection>scm:git:git://github.com:maxmind/minfraud-api-java.git</connection>
         <developerConnection>scm:git:git@github.com:maxmind/minfraud-api-java.git</developerConnection>
-      <tag>v3.3.0</tag>
+      <tag>HEAD</tag>
   </scm>
     <issueManagement>
         <url>https://github.com/maxmind/minfraud-api-java/issues</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.maxmind.minfraud</groupId>
     <artifactId>minfraud</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0</version>
     <name>MaxMind minFraud Score, Insights, Factors and Report Transaction API</name>
     <description>MaxMind minFraud Score, Insights, Factors and Report Transaction API</description>
     <url>http://dev.maxmind.com/minfraud</url>
@@ -23,7 +23,8 @@
         <url>https://github.com/maxmind/minfraud-api-java</url>
         <connection>scm:git:git://github.com:maxmind/minfraud-api-java.git</connection>
         <developerConnection>scm:git:git@github.com:maxmind/minfraud-api-java.git</developerConnection>
-    </scm>
+      <tag>v3.3.0</tag>
+  </scm>
     <issueManagement>
         <url>https://github.com/maxmind/minfraud-api-java/issues</url>
         <system>GitHub</system>


### PR DESCRIPTION
- Remove reminder to do release on oss.sonatype.org
- Update geoip2 to 4.2.0
- update version number in README.md
- [maven-release-plugin] prepare release v3.3.0
- [maven-release-plugin] prepare for next development iteration
- Use target/checkout/target for assets
