### PR TITLE
Add support for custom HttpClient in WebServiceClient.Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ------------------
 
 * Added `SECUREPAY` to the `Payment.Processor` enum.
+* `WebServiceClient.Builder` now has an `httpClient()` method to allow
+  passing in a custom `HttpClient`.
 
 3.8.0 (2025-06-09)
 ------------------


### PR DESCRIPTION
- Add httpClient() method to WebServiceClient.Builder
- Allow passing custom HttpClient for full control over client configuration
- Add validation to prevent conflicting configuration when custom HttpClient is provided
- Update constructor to use custom HttpClient when available
- Add comprehensive tests for new functionality

🤖 Generated with [Claude Code](https://claude.ai/code)