### PR TITLE
Use 'GeoIP'/'GeoLite' branding in documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -427,7 +427,7 @@ String json = response.toJson();  // Pretty-printed JSON output
 
 The project depends on:
 - **Jackson** (core, databind, annotations, datatype-jsr310): JSON handling
-- **GeoIP2 Java API**: Sibling library providing GeoIP2 models used in responses
+- **GeoIP Java API**: Sibling library providing GeoIP models used in responses
 - **JUnit 5** (Jupiter): Testing framework
 - **WireMock**: HTTP mocking for tests
 - **jsonassert**: JSON comparison in tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ mvn javadoc:javadoc
 - Use Java records (as of version 4.0.0) with deprecated getter methods for backwards compatibility
 - Implement `JsonSerializable` interface
 - `InsightsResponse` and `FactorsResponse` extend `ScoreResponse` with additional fields
-- Response models include GeoIP2 data (this library depends on `com.maxmind.geoip2:geoip2`)
+- Response models include GeoIP data (this library depends on `com.maxmind.geoip2:geoip2`)
 
 **Exception Hierarchy** (`src/main/java/com/maxmind/minfraud/exception/`)
 - `MinFraudException` (base checked exception)

--- a/src/main/java/com/maxmind/minfraud/response/GeoIp2Location.java
+++ b/src/main/java/com/maxmind/minfraud/response/GeoIp2Location.java
@@ -6,7 +6,7 @@ import com.maxmind.minfraud.JsonSerializable;
 import java.time.ZonedDateTime;
 
 /**
- * This class contains minFraud response data related to the GeoIP2 Insights location.
+ * This class contains minFraud response data related to the GeoIP Insights location.
  *
  * @param accuracyRadius    The approximate accuracy radius in kilometers around the latitude and
  *                          longitude for the geographical entity (country, subdivision, city or

--- a/src/test/java/com/maxmind/minfraud/WebServiceClientTest.java
+++ b/src/test/java/com/maxmind/minfraud/WebServiceClientTest.java
@@ -102,7 +102,7 @@ public class WebServiceClientTest {
         var response = client.insights(request);
 
         // We use non-strict checking as there is some extra stuff in the serialized
-        // object, most notably the "name" field in the GeoIP2 InsightsResponse subobjects.
+        // object, most notably the "name" field in the GeoIP InsightsResponse subobjects.
         // We cannot change this as it would be a breaking change to the GeoIP2 API.
         JSONAssert.assertEquals(responseContent, response.toJson(), false);
         verifyRequestFor(wireMock, "insights", "full-request");
@@ -153,7 +153,7 @@ public class WebServiceClientTest {
         var response = client.factors(request);
 
         // We use non-strict checking as there is some extra stuff in the serialized
-        // object, most notably the "name" field in the GeoIP2 InsightsResponse subobjects.
+        // object, most notably the "name" field in the GeoIP InsightsResponse subobjects.
         // We cannot change this as it would be a breaking change to the GeoIP2 API.
         JSONAssert.assertEquals(responseContent, response.toJson(), false);
         verifyRequestFor(wireMock, "factors", "full-request");

--- a/src/test/java/com/maxmind/minfraud/WebServiceClientTest.java
+++ b/src/test/java/com/maxmind/minfraud/WebServiceClientTest.java
@@ -103,7 +103,7 @@ public class WebServiceClientTest {
 
         // We use non-strict checking as there is some extra stuff in the serialized
         // object, most notably the "name" field in the GeoIP InsightsResponse subobjects.
-        // We cannot change this as it would be a breaking change to the GeoIP2 API.
+        // We cannot change this as it would be a breaking change to the GeoIP API.
         JSONAssert.assertEquals(responseContent, response.toJson(), false);
         verifyRequestFor(wireMock, "insights", "full-request");
         assertTrue(
@@ -154,7 +154,7 @@ public class WebServiceClientTest {
 
         // We use non-strict checking as there is some extra stuff in the serialized
         // object, most notably the "name" field in the GeoIP InsightsResponse subobjects.
-        // We cannot change this as it would be a breaking change to the GeoIP2 API.
+        // We cannot change this as it would be a breaking change to the GeoIP API.
         JSONAssert.assertEquals(responseContent, response.toJson(), false);
         verifyRequestFor(wireMock, "factors", "full-request");
         assertTrue(


### PR DESCRIPTION
Updates prose/documentation to refer to the products as "GeoIP"/"GeoLite" instead of "GeoIP2"/"GeoLite2". Technical identifiers (packages, class names, .mmdb filenames, edition IDs, the geolite.info hostname, URLs) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)