### PR TITLE
Add residential field to Anonymizer response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 CHANGELOG
 =========
 
+4.4.0 (unreleased)
+------------------
+
+* Added `residential` field to the `Anonymizer` response record via an
+  updated `geoip2` dependency. This is an `AnonymizerFeed` record containing
+  `confidence`, `networkLastSeen`, and `providerName` fields with residential
+  proxy data for the network. `residential` may be populated even when none
+  of the other fields on `Anonymizer` are set. This requires `geoip2` 5.2.0
+  or greater.
+
 4.3.0 (2026-05-12)
 ------------------
 

--- a/src/test/java/com/maxmind/minfraud/response/InsightsResponseTest.java
+++ b/src/test/java/com/maxmind/minfraud/response/InsightsResponseTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.maxmind.geoip2.record.AnonymizerFeed;
 import java.time.LocalDate;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,11 @@ public class InsightsResponseTest extends AbstractOutputTest {
                 .put("is_tor_exit_node", true)
                 .put("network_last_seen", "2025-01-15")
                 .put("provider_name", "TestVPN")
+                .startObjectField("residential")
+                .put("confidence", 82)
+                .put("network_last_seen", "2026-05-11")
+                .put("provider_name", "quickshift")
+                .end()
                 .end()
                 .startObjectField("country")
                 .put("iso_code", "US")
@@ -152,5 +158,24 @@ public class InsightsResponseTest extends AbstractOutputTest {
             "correct networkLastSeen"
         );
         assertEquals("TestVPN", insights.ipAddress().anonymizer().providerName(), "correct providerName");
+
+        AnonymizerFeed residential = insights.ipAddress().anonymizer().residential();
+
+        assertNotNull(residential, "anonymizer.residential() returns null");
+        assertEquals(
+            Integer.valueOf(82),
+            residential.confidence(),
+            "correct anonymizer.residential().confidence()"
+        );
+        assertEquals(
+            LocalDate.parse("2026-05-11"),
+            residential.networkLastSeen(),
+            "correct anonymizer.residential().networkLastSeen()"
+        );
+        assertEquals(
+            "quickshift",
+            residential.providerName(),
+            "correct anonymizer.residential().providerName()"
+        );
     }
 }

--- a/src/test/resources/test-data/factors-response.json
+++ b/src/test/resources/test-data/factors-response.json
@@ -24,7 +24,12 @@
       "is_residential_proxy": true,
       "is_tor_exit_node": true,
       "network_last_seen": "2025-01-15",
-      "provider_name": "TestVPN"
+      "provider_name": "TestVPN",
+      "residential": {
+        "confidence": 82,
+        "network_last_seen": "2026-05-11",
+        "provider_name": "quickshift"
+      }
     },
     "city": {
       "confidence": 42,

--- a/src/test/resources/test-data/insights-response.json
+++ b/src/test/resources/test-data/insights-response.json
@@ -24,7 +24,12 @@
       "is_residential_proxy": true,
       "is_tor_exit_node": true,
       "network_last_seen": "2025-01-15",
-      "provider_name": "TestVPN"
+      "provider_name": "TestVPN",
+      "residential": {
+        "confidence": 82,
+        "network_last_seen": "2026-05-11",
+        "provider_name": "quickshift"
+      }
     },
     "city": {
       "confidence": 42,


### PR DESCRIPTION
## Summary

Surfaces the new `residential` sub-object of the `anonymizer` object in the minFraud Insights and Factors `ip_address` response. The models reuse the GeoIP2 library's Anonymizer record, so this is a fixtures/tests/changelog change; the field flows through via the dependency.

Depends on maxmind/GeoIP2-java#740. At release time the `geoip2` dependency in pom.xml must be bumped to 5.2.0 once released; CI will be red until then since the fixtures exercise the new field.

## Testing

With geoip2 built from that PR (mvn install to the local repo; pom.xml unchanged): mvn -B test 237 tests pass; checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)