### PR TITLE
Expand email alias domain lists

### DIFF
--- a/src/main/java/com/maxmind/minfraud/request/Email.java
+++ b/src/main/java/com/maxmind/minfraud/request/Email.java
@@ -141,6 +141,7 @@ public final class Email extends AbstractModel {
                 put("fastemailer.com", true);
                 put("fastest.cc", true);
                 put("fastimap.com", true);
+                put("fastmail.ca", true);
                 put("fastmail.cn", true);
                 put("fastmail.co.uk", true);
                 put("fastmail.com", true);
@@ -235,6 +236,7 @@ public final class Email extends AbstractModel {
         fastmailDomains = Collections.unmodifiableMap(fastmailDomainsMap);
 
         HashMap<String, Boolean> yahooDomainsMap = new HashMap<>() {{
+                put("myyahoo.com", true);
                 put("y7mail.com", true);
                 put("yahoo.at", true);
                 put("yahoo.be", true);

--- a/src/test/java/com/maxmind/minfraud/request/EmailTest.java
+++ b/src/test/java/com/maxmind/minfraud/request/EmailTest.java
@@ -191,6 +191,10 @@ public class EmailTest {
         assertEquals(toMD5("user@fastmail.com"), e.address(), "MD5");
         assertEquals("user.fastmail.com", e.domain(), "domain");
 
+        e = new Builder(false).address("alias@user.fastmail.ca").hashAddress().build();
+        assertEquals(toMD5("user@fastmail.ca"), e.address(), "MD5");
+        assertEquals("user.fastmail.ca", e.domain(), "domain");
+
         e = new Builder(false).address("foo@bar.example.com").hashAddress().build();
         assertEquals(toMD5("foo@bar.example.com"), e.address(), "MD5");
         assertEquals("bar.example.com", e.domain(), "domain");
@@ -198,6 +202,10 @@ public class EmailTest {
         e = new Builder(false).address("foo-bar@ymail.com").hashAddress().build();
         assertEquals(toMD5("foo@ymail.com"), e.address(), "MD5");
         assertEquals("ymail.com", e.domain(), "domain");
+
+        e = new Builder(false).address("test-alias@myyahoo.com").hashAddress().build();
+        assertEquals(toMD5("test@myyahoo.com"), e.address(), "MD5");
+        assertEquals("myyahoo.com", e.domain(), "domain");
 
         e = new Builder(false).address("foo@example.com.com").hashAddress().build();
         assertEquals(toMD5("foo@example.com"), e.address(), "MD5");


### PR DESCRIPTION
## Summary

Adds two newly identified alias domains so more equivalent addresses
normalize to the same value before hashing:

- `fastmail.ca` — Fastmail's own Canadian domain. Confirmed via MX
  records resolving to Fastmail's `messagingengine.com` infrastructure,
  and listed on Fastmail's official domain list.
- `myyahoo.com` — an alternate Yahoo-owned signup domain (WHOIS
  registrant: Yahoo Assets LLC), functionally identical to yahoo.com.

Both run on their provider's own native mail platform with no
third-party migration history, so the existing normalization logic
applies to them exactly as it does to their canonical counterparts.

This mirrors the same addition made to the minFraud web service's own
email normalization.

## Testing

Added matching unit test cases following the existing pattern. Not run
locally — no Maven available in this environment — so CI should be
checked before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing additional Fastmail and Yahoo email domains during address normalization.

* **Bug Fixes**
  * Improved normalization, domain extraction, and MD5 handling for aliases using the newly supported domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->